### PR TITLE
Add stats pages for prerendered sites

### DIFF
--- a/SeoRender.Web/Components/Layout/NavMenu.razor
+++ b/SeoRender.Web/Components/Layout/NavMenu.razor
@@ -31,6 +31,12 @@
         </div>
 
         <div class="nav-item px-3">
+            <NavLink class="nav-link" href="stats">
+                <span class="bi bi-bar-chart-nav-menu" aria-hidden="true"></span> Stats
+            </NavLink>
+        </div>
+
+        <div class="nav-item px-3">
             <NavLink class="nav-link" href="auth">
                 <span class="bi bi-lock-nav-menu" aria-hidden="true"></span> Auth Required
             </NavLink>

--- a/SeoRender.Web/Components/Pages/DomainDetails.razor
+++ b/SeoRender.Web/Components/Pages/DomainDetails.razor
@@ -4,32 +4,47 @@
 
 <PageTitle>@Domain Stats</PageTitle>
 
-<h1>@Domain</h1>
+<div class="container">
+    <h1 class="mb-4">@Domain</h1>
 
-<input placeholder="Search URIs" value="@search" @oninput="OnSearchChanged" />
+    <div class="card mb-3">
+        <div class="card-body">
+            <div class="input-group">
+                <span class="input-group-text"><span class="bi bi-search"></span></span>
+                <input class="form-control" placeholder="Search URIs" value="@search" @oninput="OnSearchChanged" />
+            </div>
+        </div>
+    </div>
 
-<table class="table">
-    <thead>
-    <tr>
-        <th>URI</th>
-        <th>Size (bytes)</th>
-    </tr>
-    </thead>
-    <tbody>
-    @foreach (var meta in PageItems)
-    {
-        var file = Db.Storage.FindById(meta.ContentHash);
-        var size = file?.Length ?? 0;
-        <tr>
-            <td>@meta.Url</td>
-            <td>@size</td>
-        </tr>
-    }
-    </tbody>
-</table>
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>URI</th>
+                <th>Size</th>
+            </tr>
+        </thead>
+        <tbody>
+        @foreach (var meta in PageItems)
+        {
+            <tr>
+                <td>@meta.Url</td>
+                <td>@GetSize(meta)</td>
+            </tr>
+        }
+        </tbody>
+    </table>
 
-<button @onclick="PrevPage" disabled="@(_pageIndex == 0)">Previous</button>
-<button @onclick="NextPage" disabled="@((_pageIndex + 1) * PageSize >= filtered.Count)">Next</button>
+    <nav>
+        <ul class="pagination">
+            <li class="page-item @(_pageIndex == 0 ? "disabled" : null)">
+                <button class="page-link" @onclick="PrevPage">Previous</button>
+            </li>
+            <li class="page-item @(((_pageIndex + 1) * PageSize >= filtered.Count) ? "disabled" : null)">
+                <button class="page-link" @onclick="NextPage">Next</button>
+            </li>
+        </ul>
+    </nav>
+</div>
 
 @code {
     [Parameter] public string Domain { get; set; } = string.Empty;
@@ -61,6 +76,13 @@
 
     private IEnumerable<RenderedPageMeta> PageItems =>
         filtered.Skip(_pageIndex * PageSize).Take(PageSize);
+
+    private string GetSize(RenderedPageMeta meta)
+    {
+        var file = Db.Storage.FindById(meta.ContentHash);
+        var size = file?.Length ?? 0;
+        return size > 1024 ? $"{size / 1024} KB" : $"{size} B";
+    }
 
     private void PrevPage()
     {

--- a/SeoRender.Web/Components/Pages/DomainDetails.razor
+++ b/SeoRender.Web/Components/Pages/DomainDetails.razor
@@ -1,0 +1,80 @@
+@page "/stats/{Domain}"
+@using SeoRender.Web.Data
+@inject PreRenderDbContext Db
+
+<PageTitle>@Domain Stats</PageTitle>
+
+<h1>@Domain</h1>
+
+<input placeholder="Search URIs" value="@search" @oninput="OnSearchChanged" />
+
+<table class="table">
+    <thead>
+    <tr>
+        <th>URI</th>
+        <th>Size (bytes)</th>
+    </tr>
+    </thead>
+    <tbody>
+    @foreach (var meta in PageItems)
+    {
+        var file = Db.Storage.FindById(meta.ContentHash);
+        var size = file?.Length ?? 0;
+        <tr>
+            <td>@meta.Url</td>
+            <td>@size</td>
+        </tr>
+    }
+    </tbody>
+</table>
+
+<button @onclick="PrevPage" disabled="@(_pageIndex == 0)">Previous</button>
+<button @onclick="NextPage" disabled="@((_pageIndex + 1) * PageSize >= filtered.Count)">Next</button>
+
+@code {
+    [Parameter] public string Domain { get; set; } = string.Empty;
+
+    private const int PageSize = 10;
+    private int _pageIndex;
+    private string search = string.Empty;
+    private List<RenderedPageMeta> filtered = new();
+
+    protected override void OnParametersSet()
+    {
+        Load();
+    }
+
+    private void OnSearchChanged(ChangeEventArgs e)
+    {
+        search = e.Value?.ToString() ?? string.Empty;
+        _pageIndex = 0;
+        Load();
+    }
+
+    private void Load()
+    {
+        var query = Db.Metas.Find(m => m.Domain == Domain);
+        filtered = string.IsNullOrWhiteSpace(search)
+            ? query.ToList()
+            : query.Where(m => m.Url.Contains(search, StringComparison.OrdinalIgnoreCase)).ToList();
+    }
+
+    private IEnumerable<RenderedPageMeta> PageItems =>
+        filtered.Skip(_pageIndex * PageSize).Take(PageSize);
+
+    private void PrevPage()
+    {
+        if (_pageIndex > 0)
+        {
+            _pageIndex--;
+        }
+    }
+
+    private void NextPage()
+    {
+        if ((_pageIndex + 1) * PageSize < filtered.Count)
+        {
+            _pageIndex++;
+        }
+    }
+}

--- a/SeoRender.Web/Components/Pages/Stats.razor
+++ b/SeoRender.Web/Components/Pages/Stats.razor
@@ -1,0 +1,46 @@
+@page "/stats"
+@using SeoRender.Web.Data
+@inject PreRenderDbContext Db
+
+<PageTitle>Stats</PageTitle>
+
+<h1>Stats</h1>
+
+@if (_loading)
+{
+    <p><em>Loading...</em></p>
+}
+else
+{
+    <p>Total pages: @totalCount</p>
+    <p>Average render time: @avgRenderTimeMs.ToString("0.0") ms</p>
+
+    <h2>Domains</h2>
+    <ul>
+    @foreach (var d in domains)
+    {
+        <li><NavLink href="@($"/stats/{d.Domain}")">@d.Domain (@d.Count)</NavLink></li>
+    }
+    </ul>
+}
+
+@code {
+    private int totalCount;
+    private double avgRenderTimeMs;
+    private bool _loading = true;
+    private List<DomainInfo> domains = new();
+
+    protected override void OnInitialized()
+    {
+        var metas = Db.Metas.FindAll().ToList();
+        totalCount = metas.Count;
+        avgRenderTimeMs = metas.Any() ? metas.Average(m => m.LoadTimeMs) : 0;
+        domains = metas.GroupBy(m => m.Domain)
+            .Select(g => new DomainInfo(g.Key, g.Count()))
+            .OrderBy(d => d.Domain)
+            .ToList();
+        _loading = false;
+    }
+
+    private record DomainInfo(string Domain, int Count);
+}

--- a/SeoRender.Web/Components/Pages/Stats.razor
+++ b/SeoRender.Web/Components/Pages/Stats.razor
@@ -12,16 +12,43 @@
 }
 else
 {
-    <p>Total pages: @totalCount</p>
-    <p>Average render time: @avgRenderTimeMs.ToString("0.0") ms</p>
+    <div class="row mb-4">
+        <div class="col-sm-6 col-md-3 mb-3">
+            <div class="card text-center h-100">
+                <div class="card-body">
+                    <h5 class="card-title">Total Pages</h5>
+                    <p class="card-text">@totalCount</p>
+                </div>
+            </div>
+        </div>
+        <div class="col-sm-6 col-md-3 mb-3">
+            <div class="card text-center h-100">
+                <div class="card-body">
+                    <h5 class="card-title">Avg Render Time</h5>
+                    <p class="card-text">@avgRenderTimeMs.ToString("0.0") ms</p>
+                </div>
+            </div>
+        </div>
+    </div>
 
     <h2>Domains</h2>
-    <ul>
-    @foreach (var d in domains)
-    {
-        <li><NavLink href="@($"/stats/{d.Domain}")">@d.Domain (@d.Count)</NavLink></li>
-    }
-    </ul>
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>Domain</th>
+                <th>Pages</th>
+            </tr>
+        </thead>
+        <tbody>
+        @foreach (var d in domains)
+        {
+            <tr>
+                <td><NavLink href="@($"/stats/{d.Domain}")">@d.Domain</NavLink></td>
+                <td>@d.Count</td>
+            </tr>
+        }
+        </tbody>
+    </table>
 }
 
 @code {


### PR DESCRIPTION
## Summary
- Add stats page showing total cached pages, average render time, and domains list
- Add domain details view with search, pagination, and content size display
- Add navigation link to new stats page

## Testing
- `dotnet build SeoRender.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68a4d02476988322bc6bc877a3425aa0